### PR TITLE
Added overloaded Enqueue(Action action)

### DIFF
--- a/UnityMainThreadDispatcher.cs
+++ b/UnityMainThreadDispatcher.cs
@@ -46,6 +46,20 @@ public class UnityMainThreadDispatcher : MonoBehaviour {
 			});
 		}
 	}
+	
+        /// <summary>
+        /// Locks the queue and adds the Action to the queue
+	/// </summary>
+	/// <param name="action">function that will be executed from the main thread.</param>
+	public void Enqueue(Action action)
+	{
+		Enqueue(ActionWrapper(action));
+	}
+	IEnumerator ActionWrapper(Action a)
+	{
+		a();
+		yield return null;
+	}
 
 
 	private static UnityMainThreadDispatcher _instance = null;


### PR DESCRIPTION
This little convenience make the simplest usage a one liner:
`UnityMainThreadDispatcher.Instance().Enqueue(() => Debug.Log ("This is executed from the main thread"));`

I've implemented this in my own project and it seems to be working just fine. I'm no Unity expert, so if there are any risks to this I may not be able to tell.